### PR TITLE
Fixed: Upload image size issue (OFBIZ-12639)

### DIFF
--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -243,6 +243,11 @@ public class SecuredUpload {
          https://www.cvedetails.com/vulnerability-list/vendor_id-26/product_id-529/Microsoft-Word.html
          https://www.cvedetails.com/version-list/26/410/1/Microsoft-Excel.html
          You name it...
+         Also, the file may have been created using another charset than the one used to read it (default to OS' one).
+         I remember having searched bout that. But even
+         http://illegalargumentexception.blogspot.com/2009/05/java-rough-guide-to-character-encoding.html#javaencoding_autodetect
+         is not a 100% solution.
+         So even for text files it can be a problem and according to above there is no complete solution.
         */
         if (!isPdfFile(fileToCheck)) {
             if (getMimeTypeFromFileName(fileToCheck).equals("application/x-tika-msoffice")) {
@@ -251,7 +256,7 @@ public class SecuredUpload {
                         + "and an Excel file to CSV. For other file types try PDF.", MODULE);
                 return false;
             }
-            if (!checkMaxLinesLength(fileToCheck)) {
+            if (!isValidImageIncludingSvgFile(fileToCheck) && !checkMaxLinesLength(fileToCheck)) {
                 Debug.logError("For security reason lines over " + MAXLINELENGTH.toString() + " are not allowed", MODULE);
                 return false;
             }


### PR DESCRIPTION
SecuredUpload::checkMaxLinesLength does not work when the charset used to create the file is not the same than the one used when uploading. It's a know problem.

This at least allow images to be uploaded.

I'll check if we can improve the call in SecuredUpload::checkMaxLinesLength to FileUtils.readLines() (Apachecommons.io) according to http://illegalargumentexception.blogspot.com/2009/05/java-rough-guide-to-character-encoding.html#javaencoding_autodetect

See https://lists.apache.org/thread/dv4yjpknms5zd2l73wb8ht3s0db2wx2v for details

Improved:
Implemented:
Documented:
Completed:
Reverted:
Fixed:
(OFBIZ-)

Explanation

Thanks:
